### PR TITLE
MAINT: updating to 2020.8

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3360,7 +3360,7 @@ function main() {
             const buildDir = `${homeDir}/built-package`;
             const minicondaDir = `${homeDir}/miniconda`;
             const minicondaBinDir = `${minicondaDir}/bin`;
-            const channels = '-c qiime2-staging/label/r2020.6 -c conda-forge -c bioconda -c defaults';
+            const channels = '-c qiime2-staging/label/r2020.8 -c conda-forge -c bioconda -c defaults';
             core.addPath(minicondaBinDir);
             // TODO: fix these hacks
             core.addPath('../../_actions/qiime2/action-library-packaging/alpha1');

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function main(): Promise<void> {
     const buildDir = `${homeDir}/built-package`
     const minicondaDir = `${homeDir}/miniconda`
     const minicondaBinDir = `${minicondaDir}/bin`
-    const channels = '-c qiime2-staging/label/r2020.6 -c conda-forge -c bioconda -c defaults'
+    const channels = '-c qiime2-staging/label/r2020.8 -c conda-forge -c bioconda -c defaults'
 
     core.addPath(minicondaBinDir);
 


### PR DESCRIPTION
Hopefully I'm not barking up the wrong tree here, @thermokarst, but `div-lib` tests are now breaking, due to [unsatisfiable dependency issues](https://github.com/qiime2/q2-diversity-lib/pull/21/checks?check_run_id=835717436#step:4:2140).

I suspect it's because we're trying to install `qiime2=2020.8` using a [`2020.6` channel](https://github.com/qiime2/q2-diversity-lib/pull/21/checks?check_run_id=835717436#step:4:2027)? Hope this helps.