### PR TITLE
DRAFT: NEW: Cache miniconda install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
     },
     "@actions/tool-cache": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz"
     },
     "@octokit/auth-token": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
     "@actions/tool-cache": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@octokit/auth-token": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,11 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
+    "@actions/tool-cache": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
+      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
+    },
     "@octokit/auth-token": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@actions/artifact": "^0.2.0",
     "@actions/glob": "^0.1.0",
+    "@actions/tool-cache": "^1.6.0",
     "@types/temp": "^0.8.34",
     "@zeit/ncc": "^0.22.0",
     "temp": "^0.9.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir)
+    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
     core.addPath(cachedPath)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,8 +58,6 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const miniconda = tc.find('miniconda', '1')
     if(!miniconda)
     {
-      // Can we check the contents of the bindir here maybe? and load it if we have
-      // something cached
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,20 +56,21 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     core.addPath(minicondaBinDir);
     const miniconda = tc.find('miniconda', '1', 'x64')
+    core.addPath(miniconda)
     if(miniconda === '')
     {
-      // throw Error('No cache')
+      throw Error('No cache')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 
       await execWrapper('./miniconda.sh', ['-b', '-p', minicondaDir])
 
       await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
-    }
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
-    // throw Error(cachedPath)
-    core.addPath(cachedPath)
+      const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+      // throw Error(cachedPath)
+      core.addPath(cachedPath)
+    }
 }
 
 async function installCondaBuild() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,15 +56,15 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     core.addPath(minicondaDir);
 
-    const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
-    // throw Error(cachedPath)
-    core.addPath(cachedPath)
+    // const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
+    // // throw Error(cachedPath)
+    // core.addPath(cachedPath)
 
-    const miniconda = tc.find('miniconda', '1', 'x64')
+    const miniconda = tc.fiminicondaBinDirnd('miniconda', '1', 'x64')
     core.addPath(miniconda)
     if(miniconda === '')
     {
-      throw Error('No cache')
+      // throw Error('No cache')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 
@@ -72,7 +72,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
       await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-      const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+      const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
       // throw Error(cachedPath)
       core.addPath(cachedPath)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,8 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaBinDir = `${minicondaDir}/bin`
 
     core.addPath(minicondaBinDir);
+    // What does this even do? Their docs are so vague. Do I NEED a version?
+    const miniconda = tc.find('miniconda')
 
     // Can we check the contents of the bindir here maybe? and load it if we have
     // something cached
@@ -65,7 +67,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda')
     core.addPath(cachedPath)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,6 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const miniconda = tc.find('miniconda', '1')
     if(miniconda === '')
     {
-      throw Error('NOTHING FOUND')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 
@@ -68,6 +67,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     }
 
     const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    throw Error(cachedPath)
     core.addPath(cachedPath)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     // // throw Error(cachedPath)
     // core.addPath(cachedPath)
 
-    const miniconda = tc.fiminicondaBinDirnd('miniconda', '1', 'x64')
+    const miniconda = tc.find('miniconda', '1', 'x64')
     core.addPath(miniconda)
     if(miniconda === '')
     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     // core.addPath(miniconda)
     if(miniconda === '')
     {
-      // throw Error('No cache')
+      throw Error('No cache')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,11 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaBinDir = `${minicondaDir}/bin`
 
     core.addPath(minicondaBinDir);
+
+    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    // throw Error(cachedPath)
+    core.addPath(cachedPath)
+
     const miniconda = tc.find('miniconda', '1', 'x64')
     core.addPath(miniconda)
     if(miniconda === '')

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaDir = `${homeDir}/miniconda`
     const minicondaBinDir = `${minicondaDir}/bin`
 
-    core.addPath(minicondaDir);
+    core.addPath(minicondaBinDir);
 
     // const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
     // // throw Error(cachedPath)

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
-import * as tc from '@actions/tool-cache'
+// import * as tc from '@actions/tool-cache'
 
 class ExecOptions {
   public listeners: object = {}
@@ -54,7 +54,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaDir = `${homeDir}/miniconda`
     const minicondaBinDir = `${minicondaDir}/bin`
 
-    core.addPath(minicondaBinDir);
+    // core.addPath(minicondaBinDir);
 
     // Can we check the contents of the bindir here maybe? and load it if we have
     // something cached
@@ -65,8 +65,8 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
-    core.addPath(cachedPath)
+    // const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    // core.addPath(cachedPath)
 }
 
 async function installCondaBuild() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,9 +54,9 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaDir = `${homeDir}/miniconda`
     const minicondaBinDir = `${minicondaDir}/bin`
 
-    core.addPath(minicondaBinDir);
+    core.addPath(minicondaDir);
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
     // throw Error(cachedPath)
     core.addPath(cachedPath)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,8 +56,9 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     core.addPath(minicondaBinDir);
     const miniconda = tc.find('miniconda', '1')
-    if(!miniconda)
+    if(miniconda === '')
     {
+      throw Error('NOTHING FOUND')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,21 +60,23 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     // // throw Error(cachedPath)
     // core.addPath(cachedPath)
 
-    const miniconda = tc.find('miniconda', '1', 'x64')
+    await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
+    await execWrapper('chmod', ['+x', 'miniconda.sh'])
+
+    await execWrapper('./miniconda.sh', ['-b', '-p', minicondaDir])
+
+    await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
+
+    const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
+    // throw Error(cachedPath)
+    core.addPath(cachedPath)
+
     // core.addPath(miniconda)
+    const miniconda = tc.find('miniconda', '1', 'x64')
+    core.addPath(miniconda)
     if(miniconda === '')
     {
       throw Error('No cache')
-      await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
-      await execWrapper('chmod', ['+x', 'miniconda.sh'])
-
-      await execWrapper('./miniconda.sh', ['-b', '-p', minicondaDir])
-
-      await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
-
-      const cachedPath = await tc.cacheDir(minicondaDir, 'miniconda', '1')
-      // throw Error(cachedPath)
-      core.addPath(cachedPath)
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,8 +55,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaBinDir = `${minicondaDir}/bin`
 
     core.addPath(minicondaBinDir);
-    // What does this even do? Their docs are so vague. Do I NEED a version?
-    const miniconda = tc.find('miniconda')
+    const miniconda = tc.find('miniconda', '1')
 
     // Can we check the contents of the bindir here maybe? and load it if we have
     // something cached
@@ -67,7 +66,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda')
+    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
     core.addPath(cachedPath)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,7 +66,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
     const cachedPath = await tc.cacheDir(minicondaBinDir)
-    core.addpath(cachedPath)
+    core.addPath(cachedPath)
 }
 
 async function installCondaBuild() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const miniconda = tc.find('miniconda', '1', 'x64')
     if(miniconda === '')
     {
-      throw Error('No cache')
+      // throw Error('No cache')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 
@@ -68,7 +68,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     }
 
     const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
-    throw Error(cachedPath)
+    // throw Error(cachedPath)
     core.addPath(cachedPath)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as glob from '@actions/glob'
 import * as io from '@actions/io'
-// import * as tc from '@actions/tool-cache'
+import * as tc from '@actions/tool-cache'
 
 class ExecOptions {
   public listeners: object = {}
@@ -65,8 +65,8 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
 
-    // const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
-    // core.addPath(cachedPath)
+    const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
+    core.addPath(cachedPath)
 }
 
 async function installCondaBuild() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,9 +55,10 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaBinDir = `${minicondaDir}/bin`
 
     core.addPath(minicondaBinDir);
-    const miniconda = tc.find('miniconda', '1')
+    const miniconda = tc.find('miniconda', '1', 'x64')
     if(miniconda === '')
     {
+      throw Error('No cache')
       await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
       await execWrapper('chmod', ['+x', 'miniconda.sh'])
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     // core.addPath(cachedPath)
 
     const miniconda = tc.find('miniconda', '1', 'x64')
-    core.addPath(miniconda)
+    // core.addPath(miniconda)
     if(miniconda === '')
     {
       // throw Error('No cache')

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
     const minicondaDir = `${homeDir}/miniconda`
     const minicondaBinDir = `${minicondaDir}/bin`
 
-    // core.addPath(minicondaBinDir);
+    core.addPath(minicondaBinDir);
 
     // Can we check the contents of the bindir here maybe? and load it if we have
     // something cached

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,15 +56,17 @@ async function installMiniconda(homeDir: string | undefined, condaURL: string) {
 
     core.addPath(minicondaBinDir);
     const miniconda = tc.find('miniconda', '1')
+    if(!miniconda)
+    {
+      // Can we check the contents of the bindir here maybe? and load it if we have
+      // something cached
+      await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
+      await execWrapper('chmod', ['+x', 'miniconda.sh'])
 
-    // Can we check the contents of the bindir here maybe? and load it if we have
-    // something cached
-    await execWrapper('wget', ['-O', 'miniconda.sh', condaURL])
-    await execWrapper('chmod', ['+x', 'miniconda.sh'])
+      await execWrapper('./miniconda.sh', ['-b', '-p', minicondaDir])
 
-    await execWrapper('./miniconda.sh', ['-b', '-p', minicondaDir])
-
-    await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
+      await execWrapper('conda', ['upgrade', '-n', 'base', '-q', '-y', '-c', 'defaults', '--override-channels', 'conda'])
+    }
 
     const cachedPath = await tc.cacheDir(minicondaBinDir, 'miniconda', '1')
     core.addPath(cachedPath)


### PR DESCRIPTION
Closes #5. It seems like what we're going to want to do is cache the `minicondaBinDir`. Presumably we'll need to try to get the cached thing. If we get a thing use it. If we don't get anything then go through the install. The docs on Github aren't very complete, so I'm going to look for more elsewhere.

REF: https://github.com/actions/toolkit/tree/main/packages/tool-cache