### PR TITLE
bug: stop appending build hashes to filenames

### DIFF
--- a/bin/alp-1c8c84a3-build.sh
+++ b/bin/alp-1c8c84a3-build.sh
@@ -28,4 +28,5 @@ sudo conda build \
     --output-folder $BUILD_DIR \
     --no-anaconda-upload \
     --append-file $additional_tests_fp \
+    --old-build-string \
     $RECIPE_PATH


### PR DESCRIPTION
Until recently, all build produced static output names, like:

```
q2-diversity-2021.10.0.dev0.tar.bz2
```

Now we have build hashes appended to each package, like:

```
q2-diversity-2021.10.0.dev0-py38h9915552_0.tar.bz2
```

Its pretty nice to rely on _one build per versions_, so I propose reverting back to the old behavior in this PR.

This created a problem today when an action run succeeded on one architecture, but failed on the other:

https://github.com/qiime2/q2-feature-table/actions/runs/1360619241/attempts/2

Then it was rerun, producing successful builds for both architectures:

https://github.com/qiime2/q2-feature-table/actions/runs/1360619241

Unfortunately, when Library attempted to sync the builds:

```python
Exception: Incorrect number of file matches: [
    'osx-64/q2-feature-table-2021.10.0.dev0+1.g9f8ef29-py38h2cc8858_0.tar.bz2',
    'linux-64/q2-feature-table-2021.10.0.dev0+1.g9f8ef29-py38hf0ddef7_0.tar.bz2',
    'linux-64/q2-feature-table-2021.10.0.dev0+1.g9f8ef29-py38he50a156_0.tar.bz2']
```

Note the last two entries in that list, they represent _the same version_ of the package, just two different builds of it.