### PR TITLE
debug: pkg int looking at wrong channel

### DIFF
--- a/bin/alp-1c8c84a3-all.sh
+++ b/bin/alp-1c8c84a3-all.sh
@@ -37,7 +37,7 @@ esac
 
 case "$BUILD_TARGET" in
     dev)
-        export Q2_CHANNEL="https://packages.qiime2.org/qiime2/${dev_cycle}/tested"
+        export Q2_CHANNEL="https://packages.qiime2.org/qiime2/${dev_cycle}/staged/${distro}"
         export CBC_URL="https://raw.githubusercontent.com/qiime2/package-integration/main/${dev_cycle}/tested/conda_build_config.yaml"
         ;;
 


### PR DESCRIPTION
this PR attempts to fix the continued build failures that we suspect are being caused by package integration looking at the wrong build target (looking at the tested channel instead of staged).